### PR TITLE
API-specific HTTP Batch Endpoints

### DIFF
--- a/includes/class-ftek-gsuite-updater.php
+++ b/includes/class-ftek-gsuite-updater.php
@@ -147,7 +147,7 @@ class Ftek_GSuite_Updater {
                 });
                 
                 $this->gsuite_raw_client->setUseBatch(true);
-                $batch = new Google_Http_Batch($this->gsuite_raw_client);
+                $batch = new Google_Http_Batch($this->gsuite_raw_client, false, null, 'batch/admin/v1');
                 array_walk($response_members, function($member, $key, $batch) {
                     $user = $this->gsuite_client->users->get($member->email, array('projection'=>'full'));
                     $batch->add($user, $member->email);


### PR DESCRIPTION
See https://g.co/cloud/global-batch-deprecation
TLDR: You need to specify the api like "googleapis.com/batch/api/version" instead of "googleapis.com/batch", which is the default when no arguments are passed to the Google_Http_Batch() constructor.

The parameters 'false' and 'null' are default parameters.