### PR TITLE
Fixed variable scope error

### DIFF
--- a/includes/class-ftek-gsuite.php
+++ b/includes/class-ftek-gsuite.php
@@ -75,7 +75,7 @@ class Ftek_GSuite {
       }
       $members = $groups->$group;
       $exclude = explode(',', $exclude);
-      $members = array_filter($members, function($m) { return ($m->show && !in_array($m->email, $exclude)); });
+      $members = array_filter($members, function($m) use ($exclude) { return ($m->show && !in_array($m->email, $exclude)); });
       if (!$members) {
          return '';
       }


### PR DESCRIPTION
A common error in our apache error log. The $exclude variable was previously undefined inside the filter function.